### PR TITLE
Passe l'URL du site lors de l'envoi des emails

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -48,13 +48,14 @@ class UserController extends AmapBaseController
         $form->handleRequest($request);
         if ($form->isValid()) {
             $em = $this->getDoctrine()->getManager();
+            $website = $em->getRepository('App\Entity\Setting')->get('link', $_SERVER['APP_ENV']);
             $entity->setCreatedAt(new \DateTime());
             $em->persist($entity);
             $em->flush();
             $sendMail = $form['sendMail']->getData();
             $mailSent = 'no';
             if ($sendMail) {
-                $mailSent = $this->sendMail($entity->getEmail(),$entity->getUsername(),$entity->getPassword());
+                $mailSent = $this->sendMail($entity->getEmail(),$website,$entity->getUsername(),$entity->getPassword());
             }
 
 
@@ -266,10 +267,10 @@ class UserController extends AmapBaseController
         return $this->redirect($this->generateUrl('user_edit',array('id' => $id)));
     }
     
-    protected function sendMail($email, $lastname, $password) {
+    protected function sendMail($email, $website, $lastname, $password) {
         //$url = 'http://contrats.la-riche-en-bio.com';
         $msg = $this->renderView('Emails/new_user.html.twig',
-                array('lastname' => $lastname,'password' => $password)
+                array('website' => $website, 'lastname' => $lastname, 'password' => $password)
                 );
           
           


### PR DESCRIPTION
La version actuelle du template des mail (`templates/Emails/new_user.html.twig`) est censé include la variable twig "{{ website }}", incluant l'URL d'accès au site. Cependant cette variable n'est pas passée au template, et donc la ligne apparaît vide dans le mail.

Ce patch récupère la valeur du champs "link" de l'entité "Setting" et la passe en variable du template, permettant ainsi de l'afficher dans les mails.