### PR TITLE
Répare la page de ventilation des contrats

### DIFF
--- a/src/Repository/ContractRepository.php
+++ b/src/Repository/ContractRepository.php
@@ -361,7 +361,7 @@ class ContractRepository extends EntityRepository
           $sql .= " AND pr.fk_farm=:id_farm";
           $params['id_farm'] = $id_farm;
         }
-        $sql .= "GROUP BY u.lastname, pr.id_product,d.date ORDER BY f.sequence, pr.sequence, d.date, u.lastname";
+        $sql .= " GROUP BY u.lastname, pr.id_product,d.date ORDER BY f.sequence, pr.sequence, d.date, u.lastname";
         $stmt = $conn->prepare($sql);
         $stmt->execute($params);
         $tab = $stmt->fetchAll(\PDO::FETCH_ASSOC);


### PR DESCRIPTION
À cause d'un espace manquant, la page de ventilation des contrats retourne une erreur 500 lorsque l'ID de producteur est fourni.
L'ajout d'un espace en début de chaîne permet de concaténer le "GROUP BY" sans erreur de syntaxe SQL.