### PR TITLE
Affichage des contrats courant sur la page des contrats

### DIFF
--- a/src/Repository/ContractRepository.php
+++ b/src/Repository/ContractRepository.php
@@ -61,7 +61,7 @@ class ContractRepository extends EntityRepository
             min(d.date) as firstDistribution,
             c.fill_date_end as fillDateEnd,
             c.auto_end_hour as autoEndHour, 
-            case when c.fill_date_end <= date_sub(now(),interval 1 hour) then 1 else 0 end as isArchive
+            case when c.period_end <= date_sub(now(),interval 1 hour) then 1 else 0 end as isArchive
             from contract c
             left join distribution d on d.date between c.period_start and c.period_end
             where c.is_visible=1

--- a/templates/Purchase/index.html.twig
+++ b/templates/Purchase/index.html.twig
@@ -21,8 +21,7 @@
     <p class="text-muted">Pas de contrat ouvert.</p>
     {% endif %}
 
-    <p><a href="{{ path('contrat_list') }}">Contrats en cours</a></p>
-    <div class="page-header">Archives</div>
+    <div class="page-header">Contrats en cours</div>
     {% set hasOccurence = false %}
     {% for contract in contracts %}
       {% if not contract.isActive and not contract.isArchive %}
@@ -34,9 +33,9 @@
     <p class="text-muted">Pas de contrat en cours.</p>
     {% endif %}
 
-      <p><a href="{{ path('contrat_list_archives') }}">Archives</a></p>
+    <p><a href="{{ path('contrat_list_archives') }}">Archives</a></p>
 {% else %}
-    <p><a href="{{ path('contrat_list') }}">Contrats archivés</a></p>
+    <p><a href="{{ path('contrat_list') }}">Contrats en cours</a></p>
     <div class="page-header">Archives</div>
     {% set hasOccurence = false %}
     {% for contract in contracts %}

--- a/templates/Purchase/index.html.twig
+++ b/templates/Purchase/index.html.twig
@@ -9,7 +9,7 @@
   <div class="col-md-6 col-md-offset-3 filterable">
 
 {% if isArchive == false %}
-    <div class="page-header">Contrats en cours</div>
+    <div class="page-header">Contrats ouverts</div>
     {% set hasOccurence = false %}
     {% for contract in contracts %}
       {% if contract.isActive %}
@@ -18,34 +18,35 @@
       {% endif %}
     {% endfor %}
     {% if not hasOccurence %}
+    <p class="text-muted">Pas de contrat ouvert.</p>
+    {% endif %}
+
+    <p><a href="{{ path('contrat_list') }}">Contrats en cours</a></p>
+    <div class="page-header">Archives</div>
+    {% set hasOccurence = false %}
+    {% for contract in contracts %}
+      {% if not contract.isActive and not contract.isArchive %}
+        {% set hasOccurence = true %}
+        {% include 'Purchase/_index_contract.html.twig' with {'contract':contract, 'size':'M', 'style':'default', 'filled':filled}%}
+      {% endif %}
+    {% endfor %}
+    {% if not hasOccurence %}
     <p class="text-muted">Pas de contrat en cours.</p>
     {% endif %}
 
       <p><a href="{{ path('contrat_list_archives') }}">Archives</a></p>
 {% else %}
-    <p><a href="{{ path('contrat_list') }}">Contrats ouverts</a></p>
+    <p><a href="{{ path('contrat_list') }}">Contrats archivés</a></p>
     <div class="page-header">Archives</div>
     {% set hasOccurence = false %}
     {% for contract in contracts %}
-      {% if not contract.isActive and contract.isArchive %}
+      {% if contract.isArchive %}
         {% set hasOccurence = true %}
         {% include 'Purchase/_index_contract.html.twig' with {'contract':contract, 'size':'M', 'style':'default', 'filled':filled}%}  
       {% endif %}
     {% endfor %}
     {% if not hasOccurence %}
     <p class="text-muted">Pas de contrat archivé.</p>
-    {% endif %}
-
-    <div class="page-header">Contrats fermés</div>
-    {% set hasOccurence = false %}
-    {% for contract in contracts %}
-      {% if not contract.isActive and not contract.isArchive %}
-        {% set hasOccurence = true %}
-        {% include 'Purchase/_index_contract.html.twig' with {'contract':contract, 'size':'M', 'style':'default', 'filled':filled}%}  
-      {% endif %}
-    {% endfor %}
-    {% if not hasOccurence %}
-    <p class="text-muted">Pas de contrat fermé.</p>
     {% endif %}
 
 {%  endif %}


### PR DESCRIPTION
Proposition de solution pour le ticket https://github.com/abouchereau/easyamap/issues/11

Chaque contrat possède 2 attributs: "actif" et "archivé". Cette pull request a pour but de changer l'état "archivé" pour correspondre aux contrats dont la dernière distribution est passée, plutôt que lorsque la date de souscription est passée.

Ainsi, les contrats peuvent être dans 3 états possibles :

- ouvert : le contrat est actif
- en cours : le contrat n'est plus actif, mais la dernière date n'est pas passée
- archivé : la dernière distribution du contrat a déjà eu lieu

Cela permet ainsi aux adhérents de savoir quels contrats existent en cours d'année, pour éventuellement demander aux référent à y souscrire en cours de route.
